### PR TITLE
Call two times find_package to detect bugs related to double calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cmake-package-check fmt
 
 The command output will end with `cmake-package-check: SUCCESS.` if the package can be found (i.e. `find_package(fmt REQUIRED)` is successful), and with `cmake-package-check: FAILURE.` . In case of success the return value of the command will be 0, while it will be 1 if the package can't be found. This permits to use the command in the context of continuous integration scripts.
 
+Note that by default `cmake-package-check` calls `find_package` two times, to detect subtle bugs related that sometime happens with complex CMake config files. If you want to disable this behaviour, pass the `--disable-double-find` flag.
+
 **Note: on Windows, the command needs to run in Developer Command Prompt or Developer Powershell.**
 
 ### Check if a multiple packages exist
@@ -49,7 +51,7 @@ cmake-package-check fmt Eigen3
 
 ### Use to test in conda recipes if a CMake package is installed
 
-`cmake-package-check` can be used to quickly check in the test section of a conda recipe if a given CMake package is installed. 
+`cmake-package-check` can be used to quickly check in the test section of a conda recipe if a given CMake package is installed.
 For example, if you have a package that installs a CMake package called `CMakePackage`, you can check if the CMake package can be correctly found by adding to your recipe:
 ~~~yaml
 test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cmake-package-check
-description = A physics engine in reduced coordinates implemented with JAX.
+description = Script to check if a cmake package is available in the active environment.
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Silvio Traversaro

--- a/src/cmake_package_check/cmake_package_check.py
+++ b/src/cmake_package_check/cmake_package_check.py
@@ -5,13 +5,14 @@ import tempfile
 from jinja2 import Template, Environment, PackageLoader
 import argparse
 
-def cmake_package_check(CMakePackageNames):
+def cmake_package_check(CMakePackageNames, disable_double_find):
     temp_dir = tempfile.mkdtemp()
 
     try:
         # Prepare context for Jinja2 template
         context = {
-            'CMakePackageNames': CMakePackageNames
+            'CMakePackageNames': CMakePackageNames,
+            'disable_double_find': disable_double_find
         }
 
         # Render CMakeLists.txt from the Jinja2 template
@@ -46,9 +47,10 @@ def cmake_package_check(CMakePackageNames):
 def main():
     parser = argparse.ArgumentParser(description="Utility to check if a CMake package exists.")
     parser.add_argument("CMakePackageNames", metavar="CMakePackageNames", type=str, nargs="+", help="Names of the cmake packages to check the existence")
+    parser.add_argument("--disable-double-find", action="store_true", help="By default cmake-package-check calls find_package two times for each package, to detect subtle bugs related to double calls to find_package. This can be disable with these option.")
 
     args = parser.parse_args()
-    result = cmake_package_check(args.CMakePackageNames)
+    result = cmake_package_check(args.CMakePackageNames, disable_double_find=args.disable_double_find)
 
     print("===================================")
     print("=== Result:")

--- a/src/cmake_package_check/templates/CMakeLists.txt.in
+++ b/src/cmake_package_check/templates/CMakeLists.txt.in
@@ -3,4 +3,7 @@ cmake_minimum_required(VERSION 3.12)
 project(CMakePackageCheckTestCMakeProject)
 {% for CMakePackageName in CMakePackageNames %}
 find_package({{ CMakePackageName }} REQUIRED)
+{% if not disable_double_find %}
+find_package({{ CMakePackageName }} REQUIRED)
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
It may sometimes happen that:

~~~
find_package(pkg REQUIRED)
~~~

works, but:

~~~
find_package(pkg REQUIRED)
find_package(pkg REQUIRED)
~~~

fails. See for example https://github.com/ami-iit/biomechanical-analysis-framework/pull/26, or another common case is forgetting to add a `if(TARGET targetname)` before a call to `add_library(targetname IMPORTED)`. To catch this problems, this PR modifies `cmake-package-check` to call `find_package(pkg)` two times when it checks if `pkg` is available. 

If this behavior needs to be disabled, it can be disabled with the `--disable-double-find` option.