### PR TITLE
Set cmake_minimum_required policy_max argument to 3.29

### DIFF
--- a/src/cmake_package_check/cmake_package_check.py
+++ b/src/cmake_package_check/cmake_package_check.py
@@ -5,7 +5,7 @@ import tempfile
 from jinja2 import Template, Environment, PackageLoader
 import argparse
 
-def cmake_package_check(CMakePackageNames, disable_double_find):
+def cmake_package_check(CMakePackageNames, disable_double_find=False):
     temp_dir = tempfile.mkdtemp()
 
     try:

--- a/src/cmake_package_check/templates/CMakeLists.txt.in
+++ b/src/cmake_package_check/templates/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.29)
 
 project(CMakePackageCheckTestCMakeProject)
 {% for CMakePackageName in CMakePackageNames %}


### PR DESCRIPTION
It should help in cases like https://github.com/ami-iit/bipedal-locomotion-framework/pull/827#issuecomment-2039524932 .