### PR TITLE
Add check that a list of targets exists and can be used in target_link_libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,6 @@ jobs:
 
     - name: Check command line test works (Threads CMake package always exists)
       shell: bash -l {0}
-      run: cmake-package-check Threads
+      run: |
+        cmake-package-check Threads
+        cmake-package-check Threads --target Threads::Threads

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ You can also check if multiple packages can be found at once, for example to che
 cmake-package-check fmt Eigen3
 ~~~
 
+### Check if a target is defined by a package and is linkable
+
+You can also check if a one or more targets are defined and can be passed to `target_link_libraries` by specifying the `--targets` otpion:
+
+~~~bash
+cmake-package-check Eigen3 --targets Eigen3::Eigen
+~~~
+
 ### Use to test in conda recipes if a CMake package is installed
 
 `cmake-package-check` can be used to quickly check in the test section of a conda recipe if a given CMake package is installed.

--- a/src/cmake_package_check/cmake_package_check.py
+++ b/src/cmake_package_check/cmake_package_check.py
@@ -52,7 +52,7 @@ def main():
     parser.add_argument("--disable-double-find", action="store_true", help="By default cmake-package-check calls find_package two times for each package, to detect subtle bugs related to double calls to find_package. This can be disable with these option.")
 
     args = parser.parse_args()
-    result = cmake_package_check(args.CMakePackageNames, targets=targets, disable_double_find=args.disable_double_find)
+    result = cmake_package_check(args.CMakePackageNames, targets=args.targets, disable_double_find=args.disable_double_find)
 
     print("===================================")
     print("=== Result:")

--- a/src/cmake_package_check/cmake_package_check.py
+++ b/src/cmake_package_check/cmake_package_check.py
@@ -5,14 +5,15 @@ import tempfile
 from jinja2 import Template, Environment, PackageLoader
 import argparse
 
-def cmake_package_check(CMakePackageNames, disable_double_find=False):
+def cmake_package_check(CMakePackageNames, targets=[], disable_double_find=False):
     temp_dir = tempfile.mkdtemp()
 
     try:
         # Prepare context for Jinja2 template
         context = {
             'CMakePackageNames': CMakePackageNames,
-            'disable_double_find': disable_double_find
+            'disable_double_find': disable_double_find,
+            'targets': targets
         }
 
         # Render CMakeLists.txt from the Jinja2 template
@@ -47,10 +48,11 @@ def cmake_package_check(CMakePackageNames, disable_double_find=False):
 def main():
     parser = argparse.ArgumentParser(description="Utility to check if a CMake package exists.")
     parser.add_argument("CMakePackageNames", metavar="CMakePackageNames", type=str, nargs="+", help="Names of the cmake packages to check the existence")
+    parser.add_argument("--targets", metavar="targets", type=str, nargs="*",  help="Specify also the CMake imported target that should be checked.")
     parser.add_argument("--disable-double-find", action="store_true", help="By default cmake-package-check calls find_package two times for each package, to detect subtle bugs related to double calls to find_package. This can be disable with these option.")
 
     args = parser.parse_args()
-    result = cmake_package_check(args.CMakePackageNames, disable_double_find=args.disable_double_find)
+    result = cmake_package_check(args.CMakePackageNames, targets=targets, disable_double_find=args.disable_double_find)
 
     print("===================================")
     print("=== Result:")

--- a/src/cmake_package_check/cmake_package_check.py
+++ b/src/cmake_package_check/cmake_package_check.py
@@ -8,12 +8,17 @@ import argparse
 def cmake_package_check(CMakePackageNames, targets=[], disable_double_find=False):
     temp_dir = tempfile.mkdtemp()
 
+    if targets is None:
+        used_targets = []
+    else:
+        used_targets = targets
+
     try:
         # Prepare context for Jinja2 template
         context = {
             'CMakePackageNames': CMakePackageNames,
             'disable_double_find': disable_double_find,
-            'targets': targets
+            'targets': used_targets
         }
 
         # Render CMakeLists.txt from the Jinja2 template

--- a/src/cmake_package_check/templates/CMakeLists.txt.in
+++ b/src/cmake_package_check/templates/CMakeLists.txt.in
@@ -7,3 +7,11 @@ find_package({{ CMakePackageName }} REQUIRED)
 find_package({{ CMakePackageName }} REQUIRED)
 {% endif %}
 {% endfor %}
+
+# Create dummy executable
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake_package_check_dummy_executable.cpp "int main() {return 0;}")
+add_executable(cmake_package_check_dummy_executable ${CMAKE_CURRENT_BINARY_DIR}/cmake_package_check_dummy_executable.cpp)
+
+{% for target in targets %}
+target_link_libraries(cmake_package_check_dummy_executable PRIVATE {{ target }})
+{% endfor %}

--- a/tests/test_cmake_package_check.py
+++ b/tests/test_cmake_package_check.py
@@ -5,5 +5,13 @@ def test_threads():
     # see https://cmake.org/cmake/help/latest/module/FindThreads.html
     assert cmake_package_check(["Threads"])
 
+def test_threads_target():
+    # If CMake works fine and the platform is a "regular" one, find_package(Threads REQUIRED) should always return true,
+    # see https://cmake.org/cmake/help/latest/module/FindThreads.html
+    assert cmake_package_check(["Threads"], targets=["Threads::Threads"])
+
+def test_package_exists_but_target_not():
+    assert not cmake_package_check(["Threads"], targets=["Threads::ThisIsNotARealTargetAndWillNeverExists"])
+
 def test_non_existing_package():
     assert not cmake_package_check(["ThisIsNotACMakePackageName"])


### PR DESCRIPTION
### Check if a target is defined by a package and is linkable

You can also check if a one or more targets are defined and can be passed to `target_link_libraries` by specifying the `--targets` otpion:

~~~bash
cmake-package-check Eigen3 --targets Eigen3::Eigen
~~~